### PR TITLE
Add unshift method to put crumbs at front of array

### DIFF
--- a/src/DaveJamesMiller/Breadcrumbs/Generator.php
+++ b/src/DaveJamesMiller/Breadcrumbs/Generator.php
@@ -57,6 +57,17 @@ class Generator
         ));
     }
 
+    public function unshift($title, $url = null, array $data = array())
+    {
+        array_unshift($this->breadcrumbs, (object) array_merge($data, array(
+          'title' => $title,
+          'url' => $url,
+          // These will be altered later where necessary:
+          'first' => false,
+          'last' => false,
+        )));
+    }
+
     public function toArray()
     {
         $breadcrumbs = $this->breadcrumbs;

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -78,18 +78,18 @@ class GeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertSame('Home', $breadcrumbs[0]->title);
     }
 
-		public function testUnshift()
-		{
-			$generator = new Generator(array());
-			$generator->push('Second', 'foo');
-			$generator->unshift('Home', '/');
-			$breadcrumbs = $generator->get();
+    public function testUnshift()
+    {
+        $generator = new Generator(array());
+        $generator->push('Second', 'foo');
+        $generator->unshift('Home', '/');
+        $breadcrumbs = $generator->get();
 
-			$this->assertCount(2, $breadcrumbs);
+        $this->assertCount(2, $breadcrumbs);
 
-			$this->assertSame('Home', $breadcrumbs[0]->title);
-			$this->assertSame('/', $breadcrumbs[0]->url);
-		}
+        $this->assertSame('Home', $breadcrumbs[0]->title);
+        $this->assertSame('/', $breadcrumbs[0]->url);
+    }
 
     public function testToArray()
     {

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -78,6 +78,19 @@ class GeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertSame('Home', $breadcrumbs[0]->title);
     }
 
+		public function testUnshift()
+		{
+			$generator = new Generator(array());
+			$generator->push('Second', 'foo');
+			$generator->unshift('Home', '/');
+			$breadcrumbs = $generator->get();
+
+			$this->assertCount(2, $breadcrumbs);
+
+			$this->assertSame('Home', $breadcrumbs[0]->title);
+			$this->assertSame('/', $breadcrumbs[0]->url);
+		}
+
     public function testToArray()
     {
         $generator = new Generator(array());


### PR DESCRIPTION
We were needing this feature on a site in order to build up categories and subcategories, etc., when we could only traverse up the tree.

I'm sure there are other cases where you might want to add a crumb to the top of the stack.  :)