### PR TITLE
Add support for custom breadcrumbs action in route

### DIFF
--- a/src/CurrentRoute.php
+++ b/src/CurrentRoute.php
@@ -21,8 +21,14 @@ class CurrentRoute {
 
 		if (is_null($route))
 			return ['', []];
-
-		$name = $route->getName();
+			
+		$actions = $route->getAction();
+		
+		if(isset($actions['breadcrumbs'])) {
+			$name = $actions['breadcrumbs'];
+		} else {
+			$name = $route->getName();
+		}
 
 		if (is_null($name)) {
 			$uri = head($route->methods()) . ' /' . $route->uri();


### PR DESCRIPTION
With this change you can define your breadcrumbs separately from your route name within your routes.php file:

```php
Route::get('forums/category/{category}/{title}', array('as' => 'forums_category', 'uses' => 'ForumsController@getCategory', 'breadcrumbs'=>'category'));
```

In this example the route name is "forums_category" and the breadcrumbs name is "category". With currently functionality "Breadcrumbs::render('category')" would be called. With this pull request, "Breadcrumbs::render('forums_category')" would be called. But the route name is still used if the breadcrumbs name is not defined.