### PR TITLE
Change triple curly brackets to double curly brackets

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -45,9 +45,9 @@ The ``$data`` array's entries will be merged into the breadcrumb as properties, 
 
 .. code-block:: html+php
 
-    <li><a href="{{{ $breadcrumb->url }}}">
-        <img src="/images/icons/{{{ $breadcrumb->icon }}}">
-        {{{ $breadcrumb->title }}}
+    <li><a href="{{ $breadcrumb->url }}">
+        <img src="/images/icons/{{ $breadcrumb->icon }}">
+        {{ $breadcrumb->title }}
     </a></li>
 
 Do not use the following keys in your data array, as they will be overwritten: ``title``, ``url``, ``first``, ``last``.

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -20,9 +20,9 @@ To customise the HTML, create your own view file (e.g. ``resources/views/_partia
         <ul class="breadcrumb">
             @foreach ($breadcrumbs as $breadcrumb)
                 @if (!$breadcrumb->last)
-                    <li><a href="{{{ $breadcrumb->url }}}">{{{ $breadcrumb->title }}}</a></li>
+                    <li><a href="{{ $breadcrumb->url }}">{{ $breadcrumb->title }}</a></li>
                 @else
-                    <li class="active">{{{ $breadcrumb->title }}}</li>
+                    <li class="active">{{ $breadcrumb->title }}</li>
                 @endif
             @endforeach
         </ul>

--- a/views/bootstrap2.blade.php
+++ b/views/bootstrap2.blade.php
@@ -3,17 +3,17 @@
 		@foreach ($breadcrumbs as $breadcrumb)
 			@if ($breadcrumb->last)
 				<li class="active">
-					{{{ $breadcrumb->title }}}
+					{{ $breadcrumb->title }}
 				</li>
 			@elseif ($breadcrumb->url)
 				<li>
-					<a href="{{{ $breadcrumb->url }}}">{{{ $breadcrumb->title }}}</a>
+					<a href="{{ $breadcrumb->url }}">{{ $breadcrumb->title }}</a>
 					<span class="divider">/</span>
 				</li>
 			@else
 				{{-- Using .active to give it the right colour (grey by default) --}}
 				<li class="active">
-					{{{ $breadcrumb->title }}}
+					{{ $breadcrumb->title }}
 					<span class="divider">/</span>
 				</li>
 			@endif

--- a/views/bootstrap3.blade.php
+++ b/views/bootstrap3.blade.php
@@ -2,9 +2,9 @@
 	<ol class="breadcrumb">
 		@foreach ($breadcrumbs as $breadcrumb)
 			@if ($breadcrumb->url && !$breadcrumb->last)
-				<li><a href="{{{ $breadcrumb->url }}}">{{{ $breadcrumb->title }}}</a></li>
+				<li><a href="{{ $breadcrumb->url }}">{{ $breadcrumb->title }}</a></li>
 			@else
-				<li class="active">{{{ $breadcrumb->title }}}</li>
+				<li class="active">{{ $breadcrumb->title }}</li>
 			@endif
 		@endforeach
 	</ol>


### PR DESCRIPTION
The `{{{ ... }}}` is now equivalent to `{{ ... }}` as of Laravel 5.
See: https://laravel.com/docs/5.2/upgrade#upgrade-5.0

This also shows up as errors in IDE's such as PHPStorm.

Therefore, the blade templates and docs has been updated to remove this deprecated feature.