### PR TITLE
proposal: Allow to push the title as html

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -1,5 +1,7 @@
 <?php namespace DaveJamesMiller\Breadcrumbs;
 
+use Illuminate\Support\HtmlString;
+
 class Generator {
 
 	protected $breadcrumbs = [];
@@ -45,6 +47,11 @@ class Generator {
 			'first' => false,
 			'last' => false,
 		]);
+	}
+	
+	public function pushHtml($title, $url = null, array $data = [])
+	{
+		return $this->push(new HtmlString($title), $url, $data);
 	}
 
 	public function toArray()


### PR DESCRIPTION
it allows to push a title as html string and that is not encoded with blade.

```php

Breadcrumbs::register('users', function ($generator) {
   $generator->pushHtml('<i class="fa fa-users"></i> Users', 'path/to/users');
});

```