### PR TITLE
Added string class support

### DIFF
--- a/config/breadcrumbs.php
+++ b/config/breadcrumbs.php
@@ -3,5 +3,6 @@
 return [
 
 	'view' => 'breadcrumbs::bootstrap3',
+    'namespace' => '',
 
 ];

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DaveJamesMiller\Breadcrumbs;
+
+abstract class Breadcrumbs
+{
+    /**
+     * @var Generator
+     */
+    protected $generator;
+
+
+    /**
+     * Breadcrumbs constructor.
+     *
+     * @param Generator $generator
+     */
+    public function __construct(Generator $generator)
+    {
+        $this->generator = $generator;
+    }
+}

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -15,7 +15,18 @@ class Manager {
 		$this->generator    = $generator;
 		$this->currentRoute = $currentRoute;
 		$this->view         = $view;
-	}
+    }
+
+    public function registerFromRoutes(RouteCollection $routes) {
+        foreach ($routes as $route) {
+            $name = array_get($route, 'name');
+            $breadcrumbs = array_get($route, 'breadcrumb');
+
+            if($name && $breadcrumbs) {
+                $this->register($name, $breadcrumbs);
+            }
+        }
+    }
 
 	public function register($name, $callback)
 	{

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace DaveJamesMiller\Breadcrumbs;
+
+use Illuminate\Routing\Route;
+use Illuminate\Support\Collection;
+
+class RouteCollection extends Collection
+{
+
+    /**
+     * RouteCollection constructor.
+     *
+     * @param \Illuminate\Routing\RouteCollection $collection
+     */
+    public function __construct(\Illuminate\Routing\RouteCollection $collection)
+    {
+        $items = $this->parseRoutes($collection);
+
+        parent::__construct($items);
+    }
+
+    private function parseRoutes($collection)
+    {
+        $result = [];
+
+        foreach ($collection as $route) {
+            if($info = $this->getRouteInformation($route)) {
+                $result[] = $info;
+            }
+        }
+
+        return $result;
+    }
+
+    protected function getRouteInformation(Route $route)
+    {
+        $name = $route->getName();
+        $breadcrumb = array_get($route->getAction(), 'breadcrumb', null);
+
+        if ($breadcrumb === null) {
+            return null;
+        }
+
+        return compact('name', 'breadcrumb');
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,5 +1,6 @@
 <?php namespace DaveJamesMiller\Breadcrumbs;
 
+use Illuminate\Container\Container;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
 class ServiceProvider extends BaseServiceProvider {
@@ -31,6 +32,10 @@ class ServiceProvider extends BaseServiceProvider {
 	 */
 	public function register()
 	{
+	    $this->app->bind('DaveJamesMiller\Breadcrumbs\Generator', function ($app) {
+	        return new Generator(new Container(), $app['config']['breadcrumbs.namespace']);
+        });
+
 		$this->app['breadcrumbs'] = $this->app->share(function($app)
 		{
 			$breadcrumbs = $this->app->make('DaveJamesMiller\Breadcrumbs\Manager');
@@ -62,6 +67,7 @@ class ServiceProvider extends BaseServiceProvider {
 		]);
 
 		$this->registerBreadcrumbs();
+		$this->registerRoutesBreadcrumbs();
 	}
 
 	// This method can be overridden in a child class
@@ -73,5 +79,12 @@ class ServiceProvider extends BaseServiceProvider {
 			require $file;
 		}
 	}
+
+    private function registerRoutesBreadcrumbs()
+    {
+        $routes = new RouteCollection($this->app['router']->getRoutes());
+
+        $this->app['breadcrumbs']->registerFromRoutes($routes);
+    }
 
 }

--- a/tests/unit/GeneratorTest.php
+++ b/tests/unit/GeneratorTest.php
@@ -9,7 +9,7 @@ class GeneratorTest extends TestCase {
 	{
 		parent::setUp();
 
-		$this->generator = new Generator;
+		$this->generator = new Generator(null, null);
 	}
 
 	public function testCallbacks()

--- a/tests/unit/GeneratorTest.php
+++ b/tests/unit/GeneratorTest.php
@@ -22,6 +22,39 @@ class GeneratorTest extends TestCase {
 		], 'sample', []);
 	}
 
+	public function testClassCallbacks()
+	{
+        $breadcrumbs = $this->generator->generate([
+			'sample' => ExampleAction::class.'@sample',
+		], 'sample', []);
+
+        $this->assertCount(1, $breadcrumbs);
+	}
+
+	public function testClassInvokeCallbacks()
+	{
+        $breadcrumbs = $this->generator->generate([
+			'sample' => ExampleAction::class,
+		], 'sample', []);
+
+        $this->assertCount(2, $breadcrumbs);
+	}
+
+	public function testClassCallbacks_error()
+	{
+	    $isError = false;
+
+	    try {
+            $this->generator->generate([
+                'sample' => ExampleAction::class.'@fail',
+            ], 'sample', []);
+        } catch (Exception $e) {
+            $isError = true;
+        }
+
+        $this->assertTrue($isError);
+	}
+
 	public function testCallbackParameters()
 	{
 		$this->generator->generate([
@@ -186,4 +219,18 @@ class GeneratorTest extends TestCase {
 		$this->assertTrue($breadcrumbs[2]->last, '$breadcrumbs[2]->last');
 	}
 
+}
+
+class ExampleAction {
+
+    public function sample(Generator $generator)
+    {
+        $generator->push('Level 1');
+    }
+
+    public function __invoke(Generator $generator)
+    {
+        $generator->push('Level 1');
+        $generator->push('Level 2');
+    }
 }

--- a/tests/unit/GeneratorTest.php
+++ b/tests/unit/GeneratorTest.php
@@ -25,7 +25,7 @@ class GeneratorTest extends TestCase {
 	public function testClassCallbacks()
 	{
         $breadcrumbs = $this->generator->generate([
-			'sample' => ExampleAction::class.'@sample',
+			'sample' => 'ExampleAction@sample',
 		], 'sample', []);
 
         $this->assertCount(1, $breadcrumbs);
@@ -34,7 +34,7 @@ class GeneratorTest extends TestCase {
 	public function testClassInvokeCallbacks()
 	{
         $breadcrumbs = $this->generator->generate([
-			'sample' => ExampleAction::class,
+			'sample' => 'ExampleAction',
 		], 'sample', []);
 
         $this->assertCount(2, $breadcrumbs);
@@ -46,7 +46,22 @@ class GeneratorTest extends TestCase {
 
 	    try {
             $this->generator->generate([
-                'sample' => ExampleAction::class.'@fail',
+                'sample' => 'ExampleAction@fail',
+            ], 'sample', []);
+        } catch (Exception $e) {
+            $isError = true;
+        }
+
+        $this->assertTrue($isError);
+	}
+
+	public function testClassCallbacks_wrongParamenter()
+	{
+	    $isError = false;
+
+	    try {
+            $this->generator->generate([
+                'sample' => 1234,
             ], 'sample', []);
         } catch (Exception $e) {
             $isError = true;


### PR DESCRIPTION
Add support for string classes (like routes)


This is the first step for cached Breadcrumbs.

*Example: breadcrumbs.php*
```php
<?php
/**
* The breadcrumbs.php
**/


Breadcrumbs::register('project-home', function($breadcrumbs, $param)
{
    $breadcrumbs->push('Home - ' . $param, '');
});
//Call add methode in ProjectBreadcrumbController class
Breadcrumbs::register('project-timeline', '\App\Breadcrumbs\ProjectBreadcrumbController@add');
//Call timeline methode in ProjectBreadcrumbController class
Breadcrumbs::register('project-timeline', \App\Breadcrumbs\ProjectBreadcrumbController::class.'@timeline');
//Call __invoke methode in ProjectBreadcrumbController class
Breadcrumbs::register('project-events', \App\Breadcrumbs\ProjectBreadcrumbController::class);
```

*Example: ProjectBreadcrumbController*
```php
<?php

namespace App\Breadcrumbs;

use DaveJamesMiller\Breadcrumbs\Generator;

class ProjectBreadcrumbController
{

    public function timeline(Generator $breadcrumbs, $time = '')
    {
        $breadcrumbs->push('Timeline- ' . $time, '');
    }

   public function add(Generator $breadcrumbs)
    {
        $breadcrumbs->push('Add');
    }

    function __invoke(Generator $breadcrumbs)
    {
        $breadcrumbs->push('Events', '');
    }
}
```