### PR TITLE
Render breadcrumbs as HtmlString

### DIFF
--- a/src/View.php
+++ b/src/View.php
@@ -1,6 +1,7 @@
 <?php namespace DaveJamesMiller\Breadcrumbs;
 
 use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Support\HtmlString;
 
 class View {
 
@@ -16,7 +17,9 @@ class View {
 		if (!$view)
 			throw new Exception('Breadcrumbs view not specified (check the view in config/breadcrumbs.php, and ensure DaveJamesMiller\Breadcrumbs\ServiceProvider is loaded before any dependants in config/app.php)');
 
-		return $this->factory->make($view, compact('breadcrumbs'));
+		return new HtmlString(
+			$this->factory->make($view, compact('breadcrumbs'))->render()
+		);
 	}
 
 }

--- a/src/View.php
+++ b/src/View.php
@@ -16,7 +16,7 @@ class View {
 		if (!$view)
 			throw new Exception('Breadcrumbs view not specified (check the view in config/breadcrumbs.php, and ensure DaveJamesMiller\Breadcrumbs\ServiceProvider is loaded before any dependants in config/app.php)');
 
-		return $this->factory->make($view, compact('breadcrumbs'))->render();
+		return $this->factory->make($view, compact('breadcrumbs'));
 	}
 
 }


### PR DESCRIPTION
For now, after trying to render breadcrumbs with `@content` and `@yield` I am getting escaped HTML code. Breadcrumbs should be returned as HtmlString, so Laravel will not escape code and display it as it is. Also with this change we can use `{{ }}` instead of `{!! !!}` to render breadcrumbs in view.

Another fix for displaying escaped HTML would be removing `render()` in `View::render()` method, because Laravel do not escape instances of View (https://github.com/laravel/framework/blob/5.4/src/Illuminate/View/Concerns/ManagesLayouts.php#L147)