### PR TITLE
Loosen constraints for Laravel 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
+  - 7.2
   - 7.1
-  - 7.0
 
 install:
   - travis_retry composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     "license": "MIT License",
     "require": {
         "php": ">=7.0.0",
-        "illuminate/support": "5.5.*",
-        "illuminate/view": "5.5.*"
+        "illuminate/support": "5.5.* || 5.6.*",
+        "illuminate/view": "5.5.* || 5.6.*"
     },
     "require-dev": {
-        "laravel/framework": "5.5.*",
-        "orchestra/testbench": "3.5.*",
-        "phpunit/phpunit": "6.*",
+        "laravel/framework": "5.6.*",
+        "orchestra/testbench": "3.6.*",
+        "phpunit/phpunit": "7.*",
         "php-coveralls/php-coveralls": "^1.0"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     ],
     "license": "MIT License",
     "require": {
-        "php": ">=7.0.0",
-        "illuminate/support": "5.5.* || 5.6.*",
-        "illuminate/view": "5.5.* || 5.6.*"
+        "php": ">=7.1.3",
+        "illuminate/support": "5.6.*",
+        "illuminate/view": "5.6.*"
     },
     "require-dev": {
         "laravel/framework": "5.6.*",


### PR DESCRIPTION
I know it was only released a couple of hours ago but this extends the support for Laravel 5.5 to include 5.6 as well. This allows the current version of the package to work with both versions.

It also upgrades Testbench for Laravel 5.6 so that the package is tested against it, as well as upgrading PHPUnit as that's the current version used by Laravel.