### PR TITLE
Fixing the phpunit configuration file

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,6 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
     verbose="true"
 >
 


### PR DESCRIPTION
This error shown while running on windows 8.1 with phpunit 7.2.4 / PHP 7.1.14

```
Line 17:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.
```