### PR TITLE
Mention LB 4.x correct syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ Breadcrumbs::for('post', function ($trail, $post) {
 });
 ```
 
+For Laravel Breadcrumbs 4.x use the following syntax:
+```
+<?php
+
+// Home
+Breadcrumbs::register('home', function ($breadcrumbs) {
+    $breadcrumbs->push('Home', route('home'));
+});
+...
+```
+
 See the [Defining Breadcrumbs](#defining-breadcrumbs) section for more details.
 
 


### PR DESCRIPTION
For backward compatibility better to mention the previous version even do Laravel 5.5 support was dropped on Sat 10 Feb 2018.