### PR TITLE
Updated laravel/framework for Laravel 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.1.3",
+        "php": "^7.2",
         "facade/ignition-contracts": "^1.0",
-        "laravel/framework": ">=5.6"
+        "laravel/framework": "~5.6 | ^6.0"
     },
     "require-dev": {
         "orchestra/testbench": ">=3.6",


### PR DESCRIPTION
With these changes I can use the package with `Laravel Framework 6.18.3`