### PR TITLE
[RFC] Added breadcrumbs in route

### DIFF
--- a/classes/BreadcrumbsMiddleware.php
+++ b/classes/BreadcrumbsMiddleware.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DaveJamesMiller\Breadcrumbs;
+
+use Closure;
+use DaveJamesMiller\Breadcrumbs\Facades\Breadcrumbs;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Route as RouteFacade;
+use function Opis\Closure\unserialize;
+
+class BreadcrumbsMiddleware
+{
+    /**
+     * @param Request     $request
+     * @param Closure     $next
+     * @param string|null $serialize
+     *
+     * @return mixed
+     * @throws \Throwable
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        collect(RouteFacade::getRoutes()->getIterator())
+            ->filter(function (Route $route) {
+                return array_key_exists(self::class, $route->defaults);
+            })
+            ->each(function (Route $route) {
+                $serialize = $route->defaults[self::class];
+                $callback = unserialize($serialize);
+
+                Breadcrumbs::for($route->getName(), $callback);
+            });
+
+
+        $request->route()->forgetParameter(self::class);
+
+        return $next($request);
+    }
+
+}

--- a/classes/BreadcrumbsServiceProvider.php
+++ b/classes/BreadcrumbsServiceProvider.php
@@ -5,6 +5,8 @@ namespace DaveJamesMiller\Breadcrumbs;
 // Not available until Laravel 5.8
 //use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Routing\Route;
+use function Opis\Closure\serialize;
 
 /**
  * The Laravel service provider, which registers, configures and bootstraps the package.
@@ -62,6 +64,16 @@ class BreadcrumbsServiceProvider extends ServiceProvider //implements Deferrable
 
         // Load the routes/breadcrumbs.php file
         $this->registerBreadcrumbs();
+
+        if (! Route::hasMacro('breadcrumbs')) {
+            Route::macro('breadcrumbs', function (callable $closure) {
+                /* @var Router $this */
+                $this->defaults(BreadcrumbsMiddleware::class, serialize($closure));
+
+                return $this;
+            });
+        }
+
     }
 
     /**

--- a/tests/RouteDeterminationTest.php
+++ b/tests/RouteDeterminationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+
+namespace App;
+
+use BreadcrumbsTests\Models\Post;
+use BreadcrumbsTests\TestCase;
+use DaveJamesMiller\Breadcrumbs\BreadcrumbsGenerator;
+use DaveJamesMiller\Breadcrumbs\BreadcrumbsMiddleware;
+use DaveJamesMiller\Breadcrumbs\Facades\Breadcrumbs;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+class RouteDeterminationTest extends TestCase
+{
+    public function testRender()
+    {
+        // Home
+        Route::get('/', function () {
+            return '';
+        })
+            ->name('home')
+            ->middleware(BreadcrumbsMiddleware::class)
+            ->breadcrumbs(function (BreadcrumbsGenerator $trail) {
+                $trail->push('Home', route('home'));
+            });
+
+
+        // Home > [Post]
+        Route::get('/post/{id}', function () {
+            return Breadcrumbs::render();
+        })
+            ->name('post')
+            ->middleware(BreadcrumbsMiddleware::class)
+            ->breadcrumbs(function (BreadcrumbsGenerator $trail, int $id) {
+                $trail->parent('home');
+                $trail->push(Post::findOrFail($id)->title);
+            });
+
+        $html = $this->get('/post/1')->content();
+
+        $this->assertXmlStringEqualsXmlString('
+            <ol>
+                <li><a href="http://localhost">Home</a></li>
+                <li class="current">Post 1</li>
+            </ol>
+        ', $html);
+    }
+
+    public function testDefaultParams(){
+        // Home
+        Route::get('/', function (Request $request) {
+            $this->assertFalse($request->route()->hasParameter(BreadcrumbsMiddleware::class));
+        })
+            ->name('home')
+            ->middleware(BreadcrumbsMiddleware::class)
+            ->breadcrumbs(function (BreadcrumbsGenerator $trail) {
+                $trail->push('Home', route('home'));
+            });
+
+        $this->get('/');
+    }
+}


### PR DESCRIPTION
### Description of the problem
I am always a little upset when you need to find and change bread crumbs for several routes. Due to the fact that they are indifferent files and are not related to each other. Therefore, you must first open the file with the routes to see the name of the route, then open another and find a match in it.

```php
// routes/web.php
Route::get('/')->name('home');
Route::get('/about')->name('about');
```

```php
// routes/breadcrumbs.php
Breadcrumbs::for('home', function ($trail) {
    $trail->push('Home', route('home'));
});

Breadcrumbs::for('about', function ($trail) {
    $trail->parent('home');
    $trail->push('About', route('about'));
});
```


This is not a problem when there are few routes, but when there are many in your application and there are breadcrumbs for everyone, it starts to bother.

### Proposed solution
My suggestion is very simple - combine the announcement of routes and breadcrumbs.

```php
Route::get('/')->name('home')->crumbs(function ($trail) {
    $trail->push('Home', route('home'));
});

Route::get('/about')->name('about')->crumbs(function ($trail) {
    $trail->parent('home');
    $trail->push('About', route('about'));
});
```
As you can see, we have lost the duplicate required parameter name.

### Questions and additions:


> Will we break backward compatibility? 

Not at all. This should not bring any breaking changes to the code. Instead, we add middleware that you just need to enable.

> Routes are cached, can I use them?

Of course, the definition of breadcrumbs will also be cached. And when you change it will be necessary to flush the cache.

> Will there be performance issues?

I guess not. Because we will only transfer the registration of breadcrumbs from the service provider, at the time the routes are completed. This can reduce performance, but only if you use tools like spiral/roadrunner.

### Other
What do you think about this? The repository has disabled issues, so I attached a draft implementation.