### PR TITLE
Added support arrow function

### DIFF
--- a/classes/BreadcrumbsGenerator.php
+++ b/classes/BreadcrumbsGenerator.php
@@ -76,10 +76,14 @@ class BreadcrumbsGenerator
      * @param string $name The name of the parent page.
      * @param array ...$params The parameters to pass to the closure.
      * @throws InvalidBreadcrumbException
+     *
+     * @return BreadcrumbsGenerator
      */
-    public function parent(string $name, ...$params): void
+    public function parent(string $name, ...$params): BreadcrumbsGenerator
     {
         $this->call($name, $params);
+
+        return $this;
     }
 
     /**
@@ -90,9 +94,13 @@ class BreadcrumbsGenerator
      * @param string $title The title of the page.
      * @param string|null $url The URL of the page.
      * @param array $data Optional associative array of additional data to pass to the view.
+     *
+     * @return BreadcrumbsGenerator
      */
-    public function push(string $title, string $url = null, array $data = []): void
+    public function push(string $title, string $url = null, array $data = []): BreadcrumbsGenerator
     {
         $this->breadcrumbs->push((object) array_merge($data, compact('title', 'url')));
+
+        return $this;
     }
 }

--- a/tests/AdvancedUsageTest.php
+++ b/tests/AdvancedUsageTest.php
@@ -271,4 +271,24 @@ class AdvancedUsageTest extends TestCase
 
         Breadcrumbs::render();
     }
+
+    public function testBreadcrumbsSupportForArrowFunctions()
+    {
+        Route::name('home')->get('/', function () { });
+        Route::name('blog.index')->get('/blog', function () { });
+
+        Breadcrumbs::for('home', function ($trail) {
+            $trail->push('Some Data')
+                ->push('Another Set');
+        });
+
+        Breadcrumbs::for('blog.index', function ($trail) {
+            $trail->parent('home')
+                ->push('Yet Another');
+        });
+
+        $breadcrumbs = Breadcrumbs::generate('blog.index');
+
+        $this->assertCount(3, $breadcrumbs);
+    }
 }


### PR DESCRIPTION
This sentence modifies the return value for generator methods.

**Before**

```php
Breadcrumbs::for('home', function ($trail) {
    $trail->parent('home');
    $trail->push('About');
});
```

**After**
```php
Breadcrumbs::for('home', function ($trail) {
    $trail->parent('home')->push('About');
});
```

This small change does not affect backward compatibility. At the same time, it supports arrow functions:

```php
Breadcrumbs::for('home', fn ($trail) =>
    $trail->parent('home')->push('About')
);
```